### PR TITLE
TaskAU#393

### DIFF
--- a/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
+++ b/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
@@ -81,6 +81,11 @@ openerp.web_ir_actions_act_window_message = function(instance)
                                     // clean the action as it is done in the method ``fix_view_modes``
                                     // in the main controller of the web module
                                     action = result;
+                                    if (action.type != 'ir.actions.act_window'){
+                                        self.do_action(action);
+                                        close_func();
+                                        return;
+                                    }
                                     if ( ! ('views' in action) ){
                                         view_id = action.view_id || false;
                                         if ( view_id instanceof Array ){


### PR DESCRIPTION
[FIX] arreglado que cuando tenga que devolver algo que no sea un action window, no de error de que no tiene vistas, ya que en nuestro a veces devolvemos varios act_window_message seguidos para mostrar diferentes alertas.